### PR TITLE
Fix CoreData bug using generated accessor methods

### DIFF
--- a/Source/FTASyncParent.m
+++ b/Source/FTASyncParent.m
@@ -429,11 +429,14 @@
                     continue;
                 }
                 
-                SEL selector = NSSelectorFromString([NSString stringWithFormat:@"add%@Object:", [destEntity name]]);
+                //SEL selector = NSSelectorFromString([NSString stringWithFormat:@"add%@Object:", [destEntity name]]);
+                SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@Set", relationship]);
                 if ([self respondsToSelector:selector]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-                    [self performSelector:selector withObject:localObject];
+                    //[self performSelector:selector withObject:localObject];
+                    NSMutableOrderedSet *theSet = [self performSelector:selector];
+                    [theSet addObject:localObject];
 #pragma clang diagnostic pop
                 }
             }
@@ -516,7 +519,8 @@
     for (PFObject *remoteObject in parseObjects) {
         FTASyncParent *localObject = [self FTA_localObjectForClass:entityDesc WithRemoteId:remoteObject.objectId];
         if (!localObject) {
-            FSALog(@"Could not find local object matching remote object: @%", remoteObject);
+            // Fixed parameter placeholder for remoteObject, was @%
+            FSALog(@"Could not find local object matching remote object: %@", remoteObject);
             localObject = [FTASyncParent FTA_newObjectForClass:entityDesc WithRemoteObject:remoteObject];
             //break;
         }


### PR DESCRIPTION
I adjusted the selector used in FTASyncParent.m to instead use addObject: to an NSMutableOrderedSet versus using the pre-generated accessors as I was getting the CoreData bug seen here:
http://stackoverflow.com/questions/7385439/exception-thrown-in-nsorderedset-generated-accessors

I am using a mix of unordered and ordered relationships and I have not had an issue with this.

Finally, I have not had to adjust the selector for the remove pre-generated accessor.
